### PR TITLE
fix/click-sprite-font-crash-bug

### DIFF
--- a/Engine/Rendering/font_data.cpp
+++ b/Engine/Rendering/font_data.cpp
@@ -11,21 +11,24 @@ std::shared_ptr<DirectX::SpriteBatch> FontData::m_sprite_batch_;
 
 FontData::FontData()
 {
-    auto device = g_RenderEngine->Device();
-    m_graphics_memory_ = std::make_shared<DirectX::GraphicsMemory>(device);
+    if (!m_graphics_memory_)
+    {
+        auto device = g_RenderEngine->Device();
+        m_graphics_memory_ = std::make_shared<DirectX::GraphicsMemory>(device);
 
-    DirectX::ResourceUploadBatch resource_upload_batch(device);
-    resource_upload_batch.Begin();
-    DirectX::RenderTargetState rtState(
-        DXGI_FORMAT_R8G8B8A8_UNORM,
-        DXGI_FORMAT_D32_FLOAT);
-    DirectX::SpriteBatchPipelineStateDescription pd(rtState);
+        DirectX::ResourceUploadBatch resource_upload_batch(device);
+        resource_upload_batch.Begin();
+        DirectX::RenderTargetState rtState(
+            DXGI_FORMAT_R8G8B8A8_UNORM,
+            DXGI_FORMAT_D32_FLOAT);
+        DirectX::SpriteBatchPipelineStateDescription pd(rtState);
 
-    m_sprite_batch_ = std::make_shared<DirectX::SpriteBatch>(device, resource_upload_batch, pd);
-    m_sprite_batch_->SetViewport(g_RenderEngine->ViewPort());
+        m_sprite_batch_ = std::make_shared<DirectX::SpriteBatch>(device, resource_upload_batch, pd);
+        m_sprite_batch_->SetViewport(g_RenderEngine->ViewPort());
 
-    auto future = resource_upload_batch.End(g_RenderEngine->CommandQueue());
-    future.wait();
+        auto future = resource_upload_batch.End(g_RenderEngine->CommandQueue());
+        future.wait();
+    }
 }
 
 void FontData::LoadFont(const std::wstring &font_path)


### PR DESCRIPTION
spritefontの拡張子を持つファイルをeditor上でクリックしたときにクラッシュする不具合の修正
