### PR TITLE
Refactor rendering related stuff to improve readability and fix some broken behaviours

### DIFF
--- a/Engine/Components/camera.cpp
+++ b/Engine/Components/camera.cpp
@@ -3,6 +3,7 @@
 #include "camera.h"
 #include "application.h"
 #include "game_object.h"
+#include "gui.h"
 #include "update_manager.h"
 #include "Rendering/gizmos.h"
 #include "Rendering/view_projection.h"
@@ -12,51 +13,69 @@ namespace engine
 {
 std::weak_ptr<Camera> Camera::m_main_camera_;
 
-void Camera::SetViewProjMatrix()
+void CameraProperty::OnInspectorGui()
 {
-    for (auto view_proj_matrix_buffer : m_view_proj_matrix_buffers_)
+    ImGui::SliderFloat("Field of View", &field_of_view, kMinFieldOfView, kMaxFieldOfView);
+    ImGui::SliderFloat("Near Plane", &near_plane, kMinClippingPlane, Mathf::Min(far_plane, kMaxClippingPlane));
+    ImGui::SliderFloat("Far Plane", &far_plane, Mathf::Max(near_plane, kMinClippingPlane) + 0.1F, kMaxClippingPlane);
+
+    if (Gui::PropertyField("Ortho Size", ortho_size))
     {
-        auto ptr = view_proj_matrix_buffer->GetPtr<ViewProjection>();
-        ptr->matrices[0] = GetViewMatrix();
-        ptr->matrices[1] = GetProjectionMatrix();
+        ortho_size = Mathf::Max(ortho_size, 0.1F);
     }
-    auto cmd_list = g_RenderEngine->CommandList();
-    auto current_buffer = g_RenderEngine->CurrentBackBufferIndex();
-    cmd_list->SetGraphicsRootConstantBufferView(kViewProjCBV,
-                                                m_view_proj_matrix_buffers_[current_buffer]->GetAddress());
+
+    int current_view_mode = static_cast<int>(view_mode);
+    if (ImGui::Combo("View Mode", &current_view_mode, "Perspective\0Orthographic\0\0"))
+    {
+        view_mode = static_cast<kViewMode>(current_view_mode);
+    }
+
+    Gui::PropertyField("Background Color", background_color);
+}
+
+void Camera::SetViewProjMatrix() const
+{
+    const auto cmd_list = g_RenderEngine->CommandList();
+    const auto current_buffer_idx = g_RenderEngine->CurrentBackBufferIndex();
+    const auto view_projection_buffer = m_view_proj_matrix_buffers_[current_buffer_idx];
+    const auto view_projection = view_projection_buffer->GetPtr<ViewProjection>();
+
+    view_projection->matrices[0] = GetViewMatrix();
+    view_projection->matrices[1] = GetProjectionMatrix();
+
+    cmd_list->SetGraphicsRootConstantBufferView(kViewProjCBV, view_projection_buffer->GetAddress());
 }
 
 std::vector<std::shared_ptr<Renderer>> Camera::FilterVisibleObjects(
-    const std::vector<std::weak_ptr<Renderer>> &renderers)
+    const std::vector<std::weak_ptr<Renderer>> &renderers) const
 {
     Matrix view_matrix = GetViewMatrix();
     Matrix proj_matrix = GetProjectionMatrix();
+
     DirectX::BoundingFrustum frustum;
     DirectX::BoundingFrustum::CreateFromMatrix(frustum, proj_matrix, true);
     frustum.Transform(frustum, view_matrix.Invert());
 
-    std::vector<std::shared_ptr<Renderer>> visible_objects;
-    for (auto renderer : renderers)
+    std::vector<std::shared_ptr<Renderer>> results;
+    for (auto weak_renderer : renderers)
     {
-        auto transform = renderer.lock()->BoundsOrigin();
-        auto world_matrix = transform.lock()->WorldMatrix();
-        auto bounds = renderer.lock()->bounds;
-        auto min_pos = bounds.Center + Vector3(-bounds.Extents.x, -bounds.Extents.y, -bounds.Extents.z);
-        auto max_pos = bounds.Center + Vector3(bounds.Extents.x, bounds.Extents.y, bounds.Extents.z);
-        min_pos = Vector3::Transform(min_pos, world_matrix);
-        max_pos = Vector3::Transform(max_pos, world_matrix);
-        DirectX::BoundingBox::CreateFromPoints(bounds, min_pos, max_pos);
-        if (frustum.Intersects(bounds))
+        auto renderer = weak_renderer.lock();
+        auto world_matrix = renderer->BoundsOrigin()->WorldMatrix();
+
+        DirectX::BoundingBox world_bounds;
+        renderer->bounds.Transform(world_bounds, world_matrix);
+
+        if (frustum.Intersects(world_bounds))
         {
-            visible_objects.emplace_back(renderer);
+            results.emplace_back(renderer);
         }
     }
-    return visible_objects;
+    return results;
 }
 
 void Camera::OnAwake()
 {
-    if (!m_main_camera_.lock())
+    if (m_main_camera_.lock() == nullptr)
     {
         m_main_camera_ = shared_from_base<Camera>();
     }
@@ -73,45 +92,23 @@ void Camera::OnConstructed()
 
 void Camera::OnInspectorGui()
 {
-    ImGui::SliderFloat("Field of View", &m_field_of_view_,
-                       min_field_of_view, max_field_of_view);
+    m_property_.OnInspectorGui();
 
-    ImGui::SliderFloat("Near Plane", &m_near_plane_,
-                       min_clipping_plane, Mathf::Min(m_far_plane_, max_clipping_plane));
-
-    ImGui::SliderFloat("Far Plane", &m_far_plane_,
-                       Mathf::Max(m_near_plane_, min_clipping_plane) + 0.1F, max_clipping_plane);
-
-    ImGui::InputFloat("Ortho Size", &m_ortho_size_);
-    m_ortho_size_ = Mathf::Max(m_ortho_size_, 0.1F);
-
-    int current_view_mode = static_cast<int>(m_view_mode_);
-    if (ImGui::Combo("View Mode", &current_view_mode, "Perspective\0Orthographic\0\0"))
-    {
-        m_view_mode_ = static_cast<kViewMode>(current_view_mode);
-    }
-
-    float color_buf[4];
-    EngineUtil::ToFloat4(color_buf, m_background_color_);
-    if (ImGui::ColorPicker4("Background Color", color_buf))
-    {
-        m_background_color_ = Color{color_buf[0], color_buf[1], color_buf[2], color_buf[3]};
-        g_RenderEngine->SetBackGroundColor(m_background_color_);
-    }
     ImGui::Text("DrawCall Count:%d", m_drawcall_count_);
 }
 
 void Camera::OnDraw()
 {
+    g_RenderEngine->SetBackGroundColor(m_property_.background_color);
     SetViewProjMatrix();
 
-    m_drawcall_count_ = 0;
-    auto objects_in_view = FilterVisibleObjects(Renderer::renderers);
-    for (auto object : objects_in_view)
+    const auto objects_in_view = FilterVisibleObjects(Renderer::m_renderers_);
+    for (const auto object : objects_in_view)
     {
-        m_drawcall_count_++;
         object->OnDraw();
     }
+
+    m_drawcall_count_ = objects_in_view.size();
 }
 
 void Camera::OnEnabled()
@@ -138,9 +135,22 @@ Matrix Camera::GetViewMatrix() const
 
 Matrix Camera::GetProjectionMatrix() const
 {
-    const float aspect = static_cast<float>(Application::WindowWidth()) / static_cast<float>(
-                             Application::WindowHeight());
-    return DirectX::XMMatrixPerspectiveFovRH(DirectX::XMConvertToRadians(m_field_of_view_), aspect, 0.3f, 1000.0f);
+    switch (m_property_.view_mode)
+    {
+    case kViewMode::kPerspective:
+        return DirectX::XMMatrixPerspectiveFovRH(
+            m_property_.field_of_view * Mathf::kDeg2Rad,
+            m_property_.aspect_ratio,
+            m_property_.near_plane, m_property_.far_plane);
+    case kViewMode::kOrthographic:
+        return DirectX::XMMatrixOrthographicRH(
+            m_property_.ortho_size * m_property_.aspect_ratio,
+            m_property_.ortho_size,
+            m_property_.near_plane, m_property_.far_plane);
+    default:
+        assert(false && "Invalid ViewMode");
+        return Matrix::Identity;
+    }
 }
 }
 

--- a/Engine/Components/line_renderer.cpp
+++ b/Engine/Components/line_renderer.cpp
@@ -44,23 +44,18 @@ void LineRenderer::OnDraw()
     const Matrix view = camera->GetViewMatrix();
     const Matrix proj = camera->GetProjectionMatrix();
 
-    for (auto &vp_buffer : m_view_projection_buffers_)
-    {
-        auto ptr = vp_buffer->GetPtr<Matrix>();
-        ptr[0] = view;
-        ptr[1] = proj;
-    }
+    const auto current_buffer_idx = g_RenderEngine->CurrentBackBufferIndex();
+    const auto &view_projection_buffer = m_view_projection_buffers_[current_buffer_idx];
+    const auto view_projection = view_projection_buffer->GetPtr<Matrix>();
+    view_projection[0] = view;
+    view_projection[1] = proj;
 
-    auto cmd_list = g_RenderEngine->CommandList();
-    auto currentIndex = g_RenderEngine->CurrentBackBufferIndex();
-    auto vbView = m_vertex_buffer_->View();
-    auto ibView = m_index_buffer_->View();
-
+    const auto cmd_list = g_RenderEngine->CommandList();
     cmd_list->SetPipelineState(PSOManager::Get("Line"));
-    cmd_list->SetGraphicsRootConstantBufferView(0, m_view_projection_buffers_[currentIndex]->GetAddress());
+    cmd_list->SetGraphicsRootConstantBufferView(0, view_projection_buffer->GetAddress());
     cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_LINESTRIP);
-    cmd_list->IASetVertexBuffers(0, 1, &vbView);
-    cmd_list->IASetIndexBuffer(&ibView);
+    cmd_list->IASetVertexBuffers(0, 1, m_vertex_buffer_->View());
+    cmd_list->IASetIndexBuffer(m_index_buffer_->View());
     cmd_list->DrawIndexedInstanced(m_num_indices_, 1, 0, 0, 0);
 }
 }

--- a/Engine/Components/mesh_renderer.cpp
+++ b/Engine/Components/mesh_renderer.cpp
@@ -12,22 +12,23 @@
 
 namespace engine
 {
-void MeshRenderer::UpdateWVPBuffer()
+bool MeshRenderer::m_draw_bounds_ = false;
+
+void MeshRenderer::UpdateWorldBuffer()
 {
-    for (auto &world_matrix_buffer : world_matrix_buffers)
-    {
-        auto ptr = world_matrix_buffer->GetPtr<Matrix>();
-        *ptr = GameObject()->Transform()->WorldMatrix();
-    }
+    const auto current_buffer_idx = g_RenderEngine->CurrentBackBufferIndex();
+    const auto &world_matrix_buffer = m_world_matrix_buffers_[current_buffer_idx];
+    const auto ptr = world_matrix_buffer->GetPtr<Matrix>();
+    *ptr = WorldMatrix();
 }
 
 void MeshRenderer::RecalculateBoundingBox()
 {
     auto min_pos = Vector3(0, 0, 0);
     auto max_pos = Vector3(0, 0, 0);
-    for (int i = 0; i < shared_mesh->vertices.size(); ++i)
+    for (int i = 0; i < m_shared_mesh_->vertices.size(); ++i)
     {
-        auto vertex = shared_mesh->vertices[i];
+        auto vertex = m_shared_mesh_->vertices[i];
         min_pos.x = std::min(min_pos.x, vertex.x);
         min_pos.y = std::min(min_pos.y, vertex.y);
         min_pos.z = std::min(min_pos.z, vertex.z);
@@ -36,37 +37,41 @@ void MeshRenderer::RecalculateBoundingBox()
         max_pos.y = max(max_pos.y, vertex.y);
         max_pos.z = max(max_pos.z, vertex.z);
     }
+
     DirectX::BoundingBox::CreateFromPoints(bounds, min_pos, max_pos);
 }
 
 void MeshRenderer::OnInspectorGui()
 {
+    ImGui::Checkbox("Draw Bounds", &m_draw_bounds_);
+
     if (ImGui::CollapsingHeader("Mesh"))
     {
         ImGui::Indent();
-        ImGui::Text("Vertices: %llu", shared_mesh->vertices.size());
-        ImGui::Text("Indices : %llu", shared_mesh->indices.size());
-        ImGui::Text("Faces(calc): %llu", !shared_mesh->indices.empty() ? shared_mesh->indices.size() / 3 : 0);
-        ImGui::Text("UVs : %llu", shared_mesh->uvs[0].size());
-        ImGui::Text("UV2s: %llu", shared_mesh->uvs[1].size());
-        ImGui::Text("Colors  : %llu", shared_mesh->colors.size());
-        ImGui::Text("Normals : %llu", shared_mesh->normals.size());
-        ImGui::Text("Tangents: %llu", shared_mesh->tangents.size());
-        ImGui::Text("Bone Weights: %llu", shared_mesh->bone_weights.size());
-        ImGui::Text("Bind Poses  : %llu", shared_mesh->bind_poses.size());
-        ImGui::Text("Sub Meshes  : %llu", shared_mesh->sub_meshes.size());
+        ImGui::Text("Vertices: %llu", m_shared_mesh_->vertices.size());
+        ImGui::Text("Indices : %llu", m_shared_mesh_->indices.size());
+        ImGui::Text("Faces(calc): %llu", !m_shared_mesh_->indices.empty() ? m_shared_mesh_->indices.size() / 3 : 0);
+        ImGui::Text("UVs : %llu", m_shared_mesh_->uvs[0].size());
+        ImGui::Text("UV2s: %llu", m_shared_mesh_->uvs[1].size());
+        ImGui::Text("Colors  : %llu", m_shared_mesh_->colors.size());
+        ImGui::Text("Normals : %llu", m_shared_mesh_->normals.size());
+        ImGui::Text("Tangents: %llu", m_shared_mesh_->tangents.size());
+        ImGui::Text("Bone Weights: %llu", m_shared_mesh_->bone_weights.size());
+        ImGui::Text("Bind Poses  : %llu", m_shared_mesh_->bind_poses.size());
+        ImGui::Text("Sub Meshes  : %llu", m_shared_mesh_->sub_meshes.size());
+
         if (ImGui::CollapsingHeader("Sub Meshes"))
         {
             ImGui::Indent();
-            for (auto i = 0; i < shared_mesh->sub_meshes.size(); i++)
+            for (auto i = 0; i < m_shared_mesh_->sub_meshes.size(); i++)
             {
                 if (ImGui::CollapsingHeader(("Sub Mesh " + std::to_string(i)).c_str()))
                 {
                     ImGui::Indent();
-                    ImGui::Text("Base Index: %d", shared_mesh->sub_meshes[i].base_index);
-                    ImGui::Text("Base Vert : %d", shared_mesh->sub_meshes[i].base_vertex);
-                    ImGui::Text("Index Count: %d", shared_mesh->sub_meshes[i].index_count);
-                    ImGui::Text("Vert Count : %d", shared_mesh->sub_meshes[i].vertex_count);
+                    ImGui::Text("Base Index: %d", m_shared_mesh_->sub_meshes[i].base_index);
+                    ImGui::Text("Base Vert : %d", m_shared_mesh_->sub_meshes[i].base_vertex);
+                    ImGui::Text("Index Count: %d", m_shared_mesh_->sub_meshes[i].index_count);
+                    ImGui::Text("Vert Count : %d", m_shared_mesh_->sub_meshes[i].vertex_count);
                     ImGui::Unindent();
                 }
             }
@@ -74,6 +79,7 @@ void MeshRenderer::OnInspectorGui()
         }
         ImGui::Unindent();
     }
+
     if (ImGui::CollapsingHeader("Materials"))
     {
         ImGui::Indent();
@@ -90,77 +96,82 @@ void MeshRenderer::OnInspectorGui()
         }
         ImGui::Unindent();
     }
-    ImGui::Checkbox("Draw Bounds", &m_draw_bounds_);
 }
 
 void MeshRenderer::OnDraw()
 {
     UpdateBuffers();
 
-    auto material = shared_materials[0].CastedLock();
-    auto shader = material->p_shared_shader.CastedLock();
-    auto cmd_list = g_RenderEngine->CommandList();
-    auto current_buffer = g_RenderEngine->CurrentBackBufferIndex();
-    auto vbView = vertex_buffer->View();
-    cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-    cmd_list->IASetVertexBuffers(0, 1, &vbView);
+    auto current_material = shared_materials[0].CastedLock();
+    auto current_shader = current_material->p_shared_shader.CastedLock();
 
-    if (material->IsValid())
+    const auto cmd_list = g_RenderEngine->CommandList();
+
+    cmd_list->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    cmd_list->IASetVertexBuffers(0, 1, m_vertex_buffer_->View());
+
+    if (current_material->IsValid())
     {
-        if (shader)
-            PSOManager::SetPipelineState(cmd_list, shader);
-        auto ibView = index_buffers[0]->View();
-        cmd_list->IASetIndexBuffer(&ibView);
-        cmd_list->SetGraphicsRootConstantBufferView(kWorldCBV, world_matrix_buffers[current_buffer]->GetAddress());
+        if (current_shader)
+        {
+            PSOManager::SetPipelineState(cmd_list, current_shader);
+        }
+
+        cmd_list->IASetIndexBuffer(m_index_buffers_[0]->View());
         SetDescriptorTable(cmd_list, 0);
 
-        cmd_list->DrawIndexedInstanced(shared_mesh->HasSubMeshes()
-                                           ? shared_mesh->sub_meshes[0].base_index
-                                           : shared_mesh->indices.size(), 1, 0, 0, 0);
+        const auto index_count = m_shared_mesh_->HasSubMeshes()
+                                     ? m_shared_mesh_->sub_meshes[0].base_index
+                                     : m_shared_mesh_->indices.size();
+
+        cmd_list->DrawIndexedInstanced(index_count, 1, 0, 0, 0);
     }
+
     // sub-meshes
-    for (int i = 0; i < shared_mesh->sub_meshes.size(); ++i)
+    for (int i = 0; i < m_shared_mesh_->sub_meshes.size(); ++i)
     {
-        material = shared_materials[i + 1].CastedLock();
-        if (material->IsValid())
+        current_material = shared_materials[i + 1].CastedLock();
+        if (current_material->IsValid())
         {
-            shader = material->p_shared_shader.CastedLock();
-            cmd_list->SetGraphicsRootConstantBufferView(kWorldCBV, world_matrix_buffers[current_buffer]->GetAddress());
-            if (shader)
-                PSOManager::SetPipelineState(cmd_list, shader);
-            auto ib = index_buffers[i + 1];
-            auto sub_mesh = shared_mesh->sub_meshes[i];
-            auto ibView = ib->View();
-            cmd_list->IASetIndexBuffer(&ibView);
+            auto next_shader = current_material->p_shared_shader.CastedLock();
+            if (current_shader != next_shader && next_shader != nullptr)
+            {
+                current_shader = next_shader;
+                PSOManager::SetPipelineState(cmd_list, current_shader);
+            }
+
+            cmd_list->IASetIndexBuffer(m_index_buffers_[i + 1]->View());
             SetDescriptorTable(cmd_list, i + 1);
 
+            const auto sub_mesh = m_shared_mesh_->sub_meshes[i];
             cmd_list->DrawIndexedInstanced(sub_mesh.index_count, 1, 0, 0, 0);
         }
     }
+
     if (m_draw_bounds_)
         DrawBounds();
 }
 
-void MeshRenderer::SetSharedMesh(std::shared_ptr<Mesh> mesh)
+void MeshRenderer::SetSharedMesh(const std::shared_ptr<Mesh> &mesh)
 {
-    shared_mesh = mesh;
+    m_shared_mesh_ = mesh;
     RecalculateBoundingBox();
 }
 
 void MeshRenderer::DrawBounds()
 {
-    auto matrix = BoundsOrigin().lock()->WorldMatrix();
+    const auto matrix = BoundsOrigin()->WorldMatrix();
     Gizmos::DrawBounds(bounds, Gizmos::kDefaultColor, matrix);
 }
 
-std::weak_ptr<Transform> MeshRenderer::BoundsOrigin()
+std::shared_ptr<Transform> MeshRenderer::BoundsOrigin()
 {
     return GameObject()->Transform();
 }
 
 void MeshRenderer::ReconstructBuffer()
 {
-    if (!vertex_buffer || index_buffers.empty())
+    if (!m_vertex_buffer_ || m_index_buffers_.empty())
     {
         if (buffer_creation_failed)
         {
@@ -169,7 +180,7 @@ void MeshRenderer::ReconstructBuffer()
         ReconstructMeshesBuffer();
     }
 
-    for (auto &world_matrix_buffer : world_matrix_buffers)
+    for (auto &world_matrix_buffer : m_world_matrix_buffers_)
     {
         if (!world_matrix_buffer)
         {
@@ -179,24 +190,29 @@ void MeshRenderer::ReconstructBuffer()
     }
 }
 
+Matrix MeshRenderer::WorldMatrix()
+{
+    return GameObject()->Transform()->WorldMatrix();
+}
+
 void MeshRenderer::ReconstructMeshesBuffer()
 {
     // clean up old buffers
-    if (vertex_buffer)
+    if (m_vertex_buffer_)
     {
-        vertex_buffer = nullptr;
+        m_vertex_buffer_ = nullptr;
     }
 
-    if (!index_buffers.empty())
+    if (!m_index_buffers_.empty())
     {
-        for (auto &index_buffer : index_buffers)
+        for (auto &index_buffer : m_index_buffers_)
             index_buffer = nullptr;
-        index_buffers.clear();
+        m_index_buffers_.clear();
     }
 
     // create vertex buffer
-    vertex_buffer = std::make_shared<VertexBuffer>(shared_mesh.get());
-    if (!vertex_buffer->IsValid())
+    m_vertex_buffer_ = std::make_shared<VertexBuffer>(m_shared_mesh_.get());
+    if (!m_vertex_buffer_->IsValid())
     {
         Logger::Error<MeshRenderer>("Failed to create vertex buffer!: %s", GameObject()->Name().c_str());
         buffer_creation_failed = true;
@@ -204,52 +220,58 @@ void MeshRenderer::ReconstructMeshesBuffer()
     }
 
     // create index buffer
-    const auto ib_size = shared_mesh->HasSubMeshes()
-                             ? shared_mesh->sub_meshes[0].base_index
-                             : shared_mesh->indices.size();
-    const auto indices = shared_mesh->indices.data();
+    const auto index_buffer_size = m_shared_mesh_->HasSubMeshes()
+                                       ? m_shared_mesh_->sub_meshes[0].base_index
+                                       : m_shared_mesh_->indices.size();
+    const auto indices = m_shared_mesh_->indices.data();
 
-    auto ib = std::make_shared<IndexBuffer>(ib_size * sizeof(uint32_t), indices);
+    auto ib = std::make_shared<IndexBuffer>(index_buffer_size * sizeof(uint32_t), indices);
 
     if (!ib->IsValid())
     {
-        Logger::Error<MeshRenderer>("Failed to create index buffer of '%d' for '%s'", ib_size,
+        Logger::Error<MeshRenderer>("Failed to create index buffer of '%d' for '%s'", index_buffer_size,
                                     GameObject()->Path().c_str());
         buffer_creation_failed = true;
         return;
     }
 
-    index_buffers.emplace_back(ib);
+    m_index_buffers_.emplace_back(ib);
 
     // create index buffers for sub meshes
-    for (auto i = 0; i < shared_mesh->sub_meshes.size(); i++)
+    for (auto i = 0; i < m_shared_mesh_->sub_meshes.size(); i++)
     {
-        const auto sub_mesh = shared_mesh->sub_meshes[i];
+        const auto sub_mesh = m_shared_mesh_->sub_meshes[i];
 
-        const auto sub_ib_size = sub_mesh.index_count * sizeof(uint32_t);
+        const auto sub_index_buffer_size = sub_mesh.index_count * sizeof(uint32_t);
         std::vector<uint32_t> sub_indices;
         sub_indices.insert(sub_indices.begin(),
-                           shared_mesh->indices.begin() + sub_mesh.base_index,
-                           shared_mesh->indices.begin() + sub_mesh.base_index + sub_mesh.index_count);
+                           m_shared_mesh_->indices.begin() + sub_mesh.base_index,
+                           m_shared_mesh_->indices.begin() + sub_mesh.base_index + sub_mesh.index_count);
 
-        const auto sub_ib = std::make_shared<IndexBuffer>(sub_ib_size, sub_indices.data());
-        if (!sub_ib->IsValid())
+        const auto sub_index_buffer = std::make_shared<IndexBuffer>(sub_index_buffer_size, sub_indices.data());
+        if (!sub_index_buffer->IsValid())
         {
             Logger::Error<MeshRenderer>("Failed to create sub index buffer!: sub mesh index: %d", i);
             continue;
         }
 
-        index_buffers.emplace_back(sub_ib);
+        m_index_buffers_.emplace_back(sub_index_buffer);
     }
 }
 
 void MeshRenderer::UpdateBuffers()
 {
     ReconstructBuffer();
-    UpdateWVPBuffer();
+    UpdateWorldBuffer();
+
+    const auto current_buffer_idx = g_RenderEngine->CurrentBackBufferIndex();
+    const auto world_matrix_buffer = m_world_matrix_buffers_[current_buffer_idx]->GetAddress();
+    const auto cmd_list = g_RenderEngine->CommandList();
+
+    cmd_list->SetGraphicsRootConstantBufferView(kWorldCBV, world_matrix_buffer);
 }
 
-void MeshRenderer::SetDescriptorTable(ID3D12GraphicsCommandList *cmd_list, int material_idx)
+void MeshRenderer::SetDescriptorTable(ID3D12GraphicsCommandList *cmd_list, const int material_idx)
 {
     const auto material = shared_materials[material_idx].CastedLock();
     const auto material_block = material->p_shared_material_block;
@@ -268,7 +290,7 @@ void MeshRenderer::SetDescriptorTable(ID3D12GraphicsCommandList *cmd_list, int m
                 continue;
             }
 
-            // +2 for engine pre-defined shader variables
+            // +3 for engine pre-defined shader variables
             const int root_param_idx = shader_type * kParameterBufferType_Count + param_i + 3;
             const auto itr = material_block->Begin(shader_type, param_type);
             const auto desc_handle = itr->handle->HandleGPU;

--- a/Engine/Components/mesh_renderer.h
+++ b/Engine/Components/mesh_renderer.h
@@ -12,18 +12,20 @@ namespace engine
 {
 class MeshRenderer : public Renderer
 {
-    std::weak_ptr<Transform> BoundsOrigin() override;
+    std::shared_ptr<Transform> BoundsOrigin() override;
 
 protected:
-    bool m_draw_bounds_ = false;
+    static bool m_draw_bounds_;
 
-    std::shared_ptr<Mesh> shared_mesh;
-    std::shared_ptr<VertexBuffer> vertex_buffer;
-    std::vector<std::shared_ptr<IndexBuffer>> index_buffers;
-    std::array<std::shared_ptr<ConstantBuffer>, RenderEngine::FRAME_BUFFER_COUNT> world_matrix_buffers;
+    std::shared_ptr<Mesh> m_shared_mesh_;
+    std::shared_ptr<VertexBuffer> m_vertex_buffer_;
+    std::vector<std::shared_ptr<IndexBuffer>> m_index_buffers_;
+    std::array<std::shared_ptr<ConstantBuffer>, RenderEngine::FRAME_BUFFER_COUNT> m_world_matrix_buffers_;
 
     virtual void ReconstructBuffer();
-    virtual void UpdateWVPBuffer();
+    virtual Matrix WorldMatrix();
+
+    void UpdateWorldBuffer();
 
     void DrawBounds();
     void RecalculateBoundingBox();
@@ -38,11 +40,11 @@ public:
     void OnInspectorGui() override;
     void OnDraw() override;
 
-    void SetSharedMesh(std::shared_ptr<Mesh> mesh);
+    void SetSharedMesh(const std::shared_ptr<Mesh> &mesh);
 
     std::shared_ptr<Mesh> GetSharedMesh()
     {
-        return shared_mesh;
+        return m_shared_mesh_;
     }
 
     virtual void UpdateBuffers();
@@ -50,7 +52,7 @@ public:
     template <class Archive>
     void serialize(Archive &ar)
     {
-        ar(cereal::base_class<Component>(this), CEREAL_NVP(shared_mesh), CEREAL_NVP(shared_materials));
+        ar(cereal::base_class<Component>(this), CEREAL_NVP(m_shared_mesh_), CEREAL_NVP(shared_materials));
     }
 };
 }

--- a/Engine/Components/renderer.cpp
+++ b/Engine/Components/renderer.cpp
@@ -4,7 +4,7 @@
 
 namespace engine
 {
-std::vector<std::weak_ptr<Renderer>> Renderer::renderers;
+std::vector<std::weak_ptr<Renderer>> Renderer::m_renderers_;
 
 void Renderer::SetVisible(const bool visible)
 {
@@ -17,16 +17,16 @@ void Renderer::SetVisible(const bool visible)
 
     if (m_is_visible_)
     {
-        renderers.emplace_back(shared_from_base<Renderer>());
+        m_renderers_.emplace_back(shared_from_base<Renderer>());
     }
     else
     {
-        const auto pos = std::ranges::find_if(renderers, [&](const auto &r) {
+        const auto pos = std::ranges::find_if(m_renderers_, [&](const auto &r) {
             return r.lock() == shared_from_base<Renderer>();
         });
-        if (pos == renderers.end())
+        if (pos == m_renderers_.end())
             return;
-        renderers.erase(pos);
+        m_renderers_.erase(pos);
     }
 }
 

--- a/Engine/Components/renderer.h
+++ b/Engine/Components/renderer.h
@@ -8,9 +8,7 @@ class Renderer : public Component
 {
     friend class Camera;
 
-    static std::vector<std::weak_ptr<Renderer>> renderers;
-
-    static void Render();
+    static std::vector<std::weak_ptr<Renderer>> m_renderers_;
 
 protected:
     bool m_is_visible_ = false;
@@ -25,6 +23,6 @@ public:
     void OnDisabled() override;
     void OnDestroy() override;
 
-    virtual std::weak_ptr<Transform> BoundsOrigin() = 0;
+    virtual std::shared_ptr<Transform> BoundsOrigin() = 0;
 };
 }

--- a/Engine/Components/skinned_mesh_renderer.h
+++ b/Engine/Components/skinned_mesh_renderer.h
@@ -9,19 +9,22 @@ class Transform;
 
 class SkinnedMeshRenderer : public MeshRenderer
 {
-    bool m_draw_bones_ = false;
+    static bool m_draw_bones_;
+
     std::array<std::shared_ptr<StructuredBuffer>, RenderEngine::FRAME_BUFFER_COUNT> m_bone_matrix_buffers_;
 
-    void DrawBones();
-    void UpdateBoneTransformsBuffer();
-    std::weak_ptr<Transform> BoundsOrigin() override;
+    Matrix WorldMatrix() override;
 
-protected:
-    void UpdateWVPBuffer() override;
+    void DrawBones() const;
+    void UpdateBoneTransformsBuffer() const;
+    std::shared_ptr<Transform> BoundsOrigin() override;
 
 public:
     constexpr static int kMaxBonesPerVertex = 4;
+
     std::vector<std::weak_ptr<Transform>> transforms;
+    std::vector<Matrix> inverted_bind_poses;
+
     AssetPtr<Transform> root_bone;
 
     void OnInspectorGui() override;
@@ -33,7 +36,10 @@ public:
     template <class Archive>
     void serialize(Archive &ar)
     {
-        ar(cereal::base_class<MeshRenderer>(this), CEREAL_NVP(shared_mesh));
+        ar(cereal::base_class<MeshRenderer>(this),
+           CEREAL_NVP(m_shared_mesh_),
+           CEREAL_NVP(transforms),
+           CEREAL_NVP(inverted_bind_poses));
     }
 };
 }

--- a/Engine/Components/text_renderer.cpp
+++ b/Engine/Components/text_renderer.cpp
@@ -52,7 +52,7 @@ void TextRenderer::OnDraw()
     g_RenderEngine->CommandList()->SetGraphicsRootSignature(RootSignature::Get());
 }
 
-std::weak_ptr<Transform> TextRenderer::BoundsOrigin()
+std::shared_ptr<Transform> TextRenderer::BoundsOrigin()
 {
     return GameObject()->Transform();
 }

--- a/Engine/Components/text_renderer.h
+++ b/Engine/Components/text_renderer.h
@@ -17,6 +17,6 @@ public:
     void OnInspectorGui() override;
     void OnDraw() override;
 
-    std::weak_ptr<Transform> BoundsOrigin() override;
+    std::shared_ptr<Transform> BoundsOrigin() override;
 };
 }

--- a/Engine/Rendering/CabotEngine/Graphics/IndexBuffer.cpp
+++ b/Engine/Rendering/CabotEngine/Graphics/IndexBuffer.cpp
@@ -53,7 +53,7 @@ bool engine::IndexBuffer::IsValid() const
     return m_IsValid;
 }
 
-D3D12_INDEX_BUFFER_VIEW engine::IndexBuffer::View() const
+D3D12_INDEX_BUFFER_VIEW *engine::IndexBuffer::View()
 {
-    return m_View;
+    return &m_View;
 }

--- a/Engine/Rendering/CabotEngine/Graphics/IndexBuffer.h
+++ b/Engine/Rendering/CabotEngine/Graphics/IndexBuffer.h
@@ -6,7 +6,7 @@ class IndexBuffer
 public:
     IndexBuffer(size_t size, const uint32_t *pInitData = nullptr);
     bool IsValid() const;
-    D3D12_INDEX_BUFFER_VIEW View() const;
+    D3D12_INDEX_BUFFER_VIEW *View();
 
 private:
     bool m_IsValid = false;

--- a/Engine/Rendering/CabotEngine/Graphics/VertexBuffer.cpp
+++ b/Engine/Rendering/CabotEngine/Graphics/VertexBuffer.cpp
@@ -135,9 +135,9 @@ VertexBuffer::VertexBuffer(UINT num_vertices, const Vertex *p_init_data)
     m_IsValid = true;
 }
 
-D3D12_VERTEX_BUFFER_VIEW VertexBuffer::View() const
+D3D12_VERTEX_BUFFER_VIEW *VertexBuffer::View()
 {
-    return m_View;
+    return &m_View;
 }
 
 bool VertexBuffer::IsValid()

--- a/Engine/Rendering/CabotEngine/Graphics/VertexBuffer.h
+++ b/Engine/Rendering/CabotEngine/Graphics/VertexBuffer.h
@@ -13,7 +13,7 @@ class VertexBuffer
 public:
     VertexBuffer(const Mesh *p_init_data); // コンストラクタでバッファを生成
     VertexBuffer(UINT num_vertices, const Vertex *p_init_data);
-    D3D12_VERTEX_BUFFER_VIEW View() const; // 頂点バッファビューを取得
+    D3D12_VERTEX_BUFFER_VIEW *View(); // 頂点バッファビューを取得
     bool IsValid(); // バッファの生成に成功したかを取得
 
     VertexBuffer(const VertexBuffer &) = delete;

--- a/Engine/Rendering/gizmos.h
+++ b/Engine/Rendering/gizmos.h
@@ -23,8 +23,6 @@ class Gizmos : public IDrawCallReceiver
     static std::vector<Vertex> m_vertices_;
 
     std::shared_ptr<VertexBuffer> m_vertex_buffers_[RenderEngine::FRAME_BUFFER_COUNT];
-    std::shared_ptr<ConstantBuffer> m_constant_buffer_;
-    std::shared_ptr<DescriptorHandle> m_desc_handle_;
 
     static void Init();
 

--- a/Engine/Rendering/model_importer.cpp
+++ b/Engine/Rendering/model_importer.cpp
@@ -121,6 +121,11 @@ void AttachMeshObject(const aiScene *scene, const aiNode *node,
             skinned_mesh_renderer->shared_materials = materials;
             skinned_mesh_renderer->transforms = bone_transforms;
             skinned_mesh_renderer->root_bone = AssetPtr<Transform>::FromManaged(root_bone);
+            skinned_mesh_renderer->inverted_bind_poses.resize(result_mesh->bind_poses.size());
+            for (int i = 0; i < result_mesh->bind_poses.size(); ++i)
+            {
+                skinned_mesh_renderer->inverted_bind_poses[i] = result_mesh->bind_poses[i].Invert();
+            }
         }
         else
         {


### PR DESCRIPTION
- Fixed renderers changing unrelated buffer in a frame 
  - Use current back buffer index instead
- Fixed Camera manually calculating world boundaries 
  - Use `BoundingBox::Transform` instead
- Fixed SkinnedMeshRenderer applying transforms twice
- Fixed Camera not applying its properties 
  - near, far, background color, persp/ortho are now respected
- Made properties of camera as separate struct
  - `struct CameraProperties`
- Misc optimization around Mesh/SkinnedMeshRenderer calls
  - Shader updates only when previously applied Shader isn't the same
- Add const to everything that can be applied
- Make BoundsOrigin return shared_ptr of Transform instead of weak_ptr