### PR TITLE
Make AddClip return AnimationState and add FindClip method

### DIFF
--- a/Engine/Animation/animation_component.cpp
+++ b/Engine/Animation/animation_component.cpp
@@ -192,7 +192,7 @@ std::shared_ptr<AnimationState> AnimationComponent::AddClip(const std::shared_pt
     return state;
 }
 
-std::shared_ptr<AnimationState> AnimationComponent::FindClip(const std::string &name)
+std::shared_ptr<AnimationState> AnimationComponent::FindClip(const std::string &name) const
 {
     const auto it = m_states_.find(name);
     if (it == m_states_.end())

--- a/Engine/Animation/animation_component.h
+++ b/Engine/Animation/animation_component.h
@@ -49,7 +49,7 @@ public:
     void Stop();
 
     std::shared_ptr<AnimationState> AddClip(const std::shared_ptr<AnimationClip> &clip, const std::string &name);
-    std::shared_ptr<AnimationState> FindClip(const std::string &name);
+    std::shared_ptr<AnimationState> FindClip(const std::string &name) const;
     void RemoveClip(const std::string &name);
     [[nodiscard]] size_t ClipCount() const;
 


### PR DESCRIPTION
- `AnimationComponent::AddClip(const std::shared_ptr<AnimationClip> &clip, std::string name)` が対応する `std::shared_ptr<AnimationState>` を返すようになりました
- `std::shared_ptr<AnimationState> AnimationComponent::FindClip(std::string name)` を追加しました
  - `AddClip` した `AnimationState` を探すことができます