### PR TITLE
Fix component events invoked at improper timing

### DIFF
--- a/Editor/editor.cpp
+++ b/Editor/editor.cpp
@@ -290,14 +290,12 @@ void Editor::PushSceneSnapshot()
     m_scene_snapshots_.emplace(serialized_scenes);
 }
 
-void Editor::PopSceneSnapshot()
+Task Editor::ApplyLastSceneSnapshot() const
 {
-    Logger::Log<Editor>("Popping scene snapshot");
-
+    Logger::Log<Editor>("Applying last scene snapshot");
     if (m_scene_snapshots_.empty())
     {
-        throw std::runtime_error("No scene snapshots to pop");
-        return;
+        throw std::runtime_error("No scene snapshots to apply");
     }
 
     const auto scenes = SceneManager::GetCurrentScenes();
@@ -306,14 +304,21 @@ void Editor::PopSceneSnapshot()
         SceneManager::DestroyScene(scene->Name());
     }
 
-    const auto snapshot = m_scene_snapshots_.front();
-    m_scene_snapshots_.pop();
+    co_await WaitForFrames(2);
 
+    const auto snapshot = m_scene_snapshots_.front();
     Logger::Log<Editor>("Restoring %d scenes", snapshot.size());
     for (auto serialized_scene : snapshot)
     {
         SceneManager::DeserializeScene(serialized_scene);
     }
+}
+
+Task Editor::PopSceneSnapshot()
+{
+    Logger::Log<Editor>("Popping scene snapshot");
+    co_await ApplyLastSceneSnapshot();
+    m_scene_snapshots_.pop();
 }
 
 void Editor::SetEditorMode(const EditorMode mode)
@@ -327,13 +332,14 @@ void Editor::SetEditorMode(const EditorMode mode)
     if (m_mode_ == EditorMode::kPlay)
     {
         PushSceneSnapshot();
+        Engine::coroutine.Start(ApplyLastSceneSnapshot());
     }
 
     Application::SetPlayMode(mode == EditorMode::kPlay);
 
     if (m_mode_ == EditorMode::kEdit)
     {
-        PopSceneSnapshot();
+        Engine::coroutine.Start(PopSceneSnapshot());
     }
 }
 

--- a/Editor/editor.cpp
+++ b/Editor/editor.cpp
@@ -306,6 +306,8 @@ Task Editor::ApplyLastSceneSnapshot() const
 
     co_await WaitForFrames(2);
 
+    Application::SetPlayMode(m_mode_ == EditorMode::kPlay);
+
     const auto snapshot = m_scene_snapshots_.front();
     Logger::Log<Editor>("Restoring %d scenes", snapshot.size());
     for (auto serialized_scene : snapshot)
@@ -329,17 +331,17 @@ void Editor::SetEditorMode(const EditorMode mode)
     if (last_mode == m_mode_)
         return;
 
-    if (m_mode_ == EditorMode::kPlay)
+    switch (m_mode_)
     {
-        PushSceneSnapshot();
-        Engine::coroutine.Start(ApplyLastSceneSnapshot());
-    }
-
-    Application::SetPlayMode(mode == EditorMode::kPlay);
-
-    if (m_mode_ == EditorMode::kEdit)
-    {
-        Engine::coroutine.Start(PopSceneSnapshot());
+        case EditorMode::kPlay: {
+            PushSceneSnapshot();
+            Engine::coroutine.Start(ApplyLastSceneSnapshot());
+            break;
+        }
+        case EditorMode::kEdit: {
+            Engine::coroutine.Start(PopSceneSnapshot());
+            break;
+        }
     }
 }
 

--- a/Editor/editor.h
+++ b/Editor/editor.h
@@ -3,6 +3,7 @@
 
 #include "enable_shared_from_base.h"
 #include "event_receivers.h"
+#include "Coroutine/task.h"
 
 namespace editor
 {
@@ -64,7 +65,8 @@ public:
     void Finalize();
 
     void PushSceneSnapshot();
-    void PopSceneSnapshot();
+    engine::Task ApplyLastSceneSnapshot() const;
+    engine::Task PopSceneSnapshot();
 
     void SetEditorMode(EditorMode mode);
     EditorMode GetEditorMode() const;

--- a/Engine/Components/component.cpp
+++ b/Engine/Components/component.cpp
@@ -7,7 +7,7 @@ namespace engine
 {
 void Component::EnsurePrepared()
 {
-    InvokeOnEnabled();
+    InvokeOnStart();
 }
 
 void Component::InvokeOnAwake()

--- a/Engine/Components/component.cpp
+++ b/Engine/Components/component.cpp
@@ -5,6 +5,65 @@
 
 namespace engine
 {
+void Component::EnsurePrepared()
+{
+    InvokeOnEnabled();
+}
+
+void Component::InvokeOnAwake()
+{
+    if (!m_has_called_awake_)
+    {
+        OnAwake();
+        m_has_called_awake_ = true;
+    }
+}
+void Component::InvokeOnStart()
+{
+    InvokeOnEnabled();
+
+    if (!m_has_called_start_)
+    {
+        OnStart();
+        m_has_called_start_ = true;
+    }
+}
+
+void Component::InvokeOnEnabled()
+{
+    InvokeOnAwake();
+
+    if (!m_has_called_enabled_)
+    {
+        OnEnabled();
+        m_has_called_enabled_ = true;
+        m_has_called_disabled_ = false;
+    }
+}
+
+void Component::InvokeOnDisabled()
+{
+    if (!m_has_called_disabled_)
+    {
+        OnDisabled();
+        m_has_called_enabled_ = false;
+        m_has_called_disabled_ = true;
+    }
+}
+
+void Component::InvokeOnUpdate()
+{
+    EnsurePrepared();
+    OnUpdate();
+}
+
+void Component::InvokeOnFixedUpdate()
+{
+    EnsurePrepared();
+    OnFixedUpdate();
+}
+
+
 Component::Component() : Object()
 { }
 void Component::OnInspectorGui()

--- a/Engine/Components/component.h
+++ b/Engine/Components/component.h
@@ -15,6 +15,14 @@ class Component : public Object
     bool m_has_called_disabled_ = false;
     std::weak_ptr<GameObject> m_game_object_ = {};
 
+    void EnsurePrepared();
+    void InvokeOnAwake();
+    void InvokeOnEnabled();
+    void InvokeOnStart();
+    void InvokeOnDisabled();
+    void InvokeOnUpdate();
+    void InvokeOnFixedUpdate();
+
 public:
     Component();
 

--- a/Engine/game_object.cpp
+++ b/Engine/game_object.cpp
@@ -20,7 +20,15 @@ void GameObject::OnConstructed()
     SceneManager::MoveGameObject(shared_from_base<GameObject>(), SceneManager::GetActiveScene());
     if (Transform() == nullptr)
         AddComponent<engine::Transform>();
+
+    UpdateActiveInHierarchy(!Application::IsPlayMode());
 }
+
+void GameObject::OnDeserialized()
+{
+    UpdateActiveInHierarchy(!Application::IsPlayMode());
+}
+
 void GameObject::OnDestroy()
 {
     // notify the scene that there is a destroying game object
@@ -60,7 +68,7 @@ void GameObject::SetActive(const bool is_active)
     }
 
     m_is_active_self_ = is_active;
-    UpdateActiveInHierarchy();
+    UpdateActiveInHierarchy(true);
 }
 
 std::shared_ptr<Scene> GameObject::Scene() const
@@ -85,53 +93,9 @@ std::string GameObject::PathFrom(const std::shared_ptr<GameObject> &parent) cons
     return path.substr(parent_path.size());
 }
 
-void GameObject::EnsureComponentPrepared(const std::shared_ptr<Component> &component)
+void GameObject::InvokeOnUpdate()
 {
-    if (!component->m_has_called_awake_)
-    {
-        component->OnAwake();
-        component->m_has_called_awake_ = true;
-    }
-
-    if (!component->m_has_called_enabled_)
-    {
-        component->OnEnabled();
-        component->m_has_called_enabled_ = true;
-        component->m_has_called_disabled_ = false;
-    }
-
-    if (!component->m_has_called_start_)
-    {
-        component->OnStart();
-        component->m_has_called_start_ = true;
-    }
-}
-
-void GameObject::InvokeComponentOnEnabled(const std::shared_ptr<Component> &component)
-{
-    EnsureComponentPrepared(component);
-    if (component->m_has_called_enabled_)
-        return;
-
-    component->OnEnabled();
-    component->m_has_called_enabled_ = true;
-    component->m_has_called_disabled_ = false;
-}
-
-void GameObject::InvokeComponentOnDisabled(const std::shared_ptr<Component> &component)
-{
-    EnsureComponentPrepared(component);
-    if (component->m_has_called_disabled_)
-        return;
-
-    component->OnDisabled();
-    component->m_has_called_enabled_ = false;
-    component->m_has_called_disabled_ = true;
-}
-
-void GameObject::InvokeUpdate()
-{
-    if (IsDestroying() || IsActiveInHierarchy() == false)
+    if (IsDestroying() || !IsActiveInHierarchy())
     {
         return;
     }
@@ -145,15 +109,16 @@ void GameObject::InvokeUpdate()
             continue;
         }
 
-        EnsureComponentPrepared(component);
-        component->OnUpdate();
+        component->InvokeOnUpdate();
     }
 
     if (has_destroying_component)
     {
         std::erase_if(
             m_components_,
-            [](const auto &component) { return component->IsDestroying(); }
+            [](const auto &component) {
+                return component->IsDestroying();
+            }
         );
     }
 
@@ -162,23 +127,22 @@ void GameObject::InvokeUpdate()
     {
         for (int i = 0; i < transform->ChildCount(); i++)
         {
-            const auto child = transform->GetChild(i)->GameObject();
-            child->InvokeUpdate();
+            const auto child_game_object = transform->GetChild(i)->GameObject();
+            child_game_object->InvokeOnUpdate();
         }
     }
 }
 
-void GameObject::InvokeFixedUpdate() const
+void GameObject::InvokeOnFixedUpdate() const
 {
-    if (IsActiveInHierarchy() == false)
+    if (!IsActiveInHierarchy())
     {
         return;
     }
 
     for (auto &component : m_components_)
     {
-        EnsureComponentPrepared(component);
-        component->OnFixedUpdate();
+        component->InvokeOnFixedUpdate();
     }
 
     const auto transform = Transform();
@@ -186,8 +150,8 @@ void GameObject::InvokeFixedUpdate() const
     {
         for (int i = 0; i < transform->ChildCount(); i++)
         {
-            const auto child = transform->GetChild(i)->GameObject();
-            child->InvokeFixedUpdate();
+            const auto child_game_object = transform->GetChild(i)->GameObject();
+            child_game_object->InvokeOnFixedUpdate();
         }
     }
 }
@@ -200,7 +164,7 @@ void GameObject::InvokeOnValidate() const
     }
 }
 
-void GameObject::UpdateActiveInHierarchy() const
+void GameObject::UpdateActiveInHierarchy(const bool invoke_component_events) const
 {
     const auto transform = Transform();
     const auto parent = transform != nullptr ? transform->Parent() : nullptr;
@@ -213,31 +177,31 @@ void GameObject::UpdateActiveInHierarchy() const
 
     m_is_active_in_hierarchy_ = active_in_hierarchy;
 
-    // not clean but it works
-    if (Application::IsPlayMode())
+    if (invoke_component_events)
     {
         for (const auto &component : m_components_)
         {
             if (m_is_active_in_hierarchy_)
             {
-                InvokeComponentOnEnabled(component);
+                component->InvokeOnEnabled();
             }
             else
             {
-                InvokeComponentOnDisabled(component);
+                component->InvokeOnDisabled();
             }
         }
-    }
-    else
-    {
-        InvokeOnValidate();
+
+        if (!Application::IsPlayMode())
+        {
+            InvokeOnValidate();
+        }
     }
 
     if (transform != nullptr)
     {
         for (int i = 0; i < transform->ChildCount(); i++)
         {
-            transform->GetChild(i)->GameObject()->UpdateActiveInHierarchy();
+            transform->GetChild(i)->GameObject()->UpdateActiveInHierarchy(invoke_component_events);
         }
     }
 }

--- a/Engine/game_object.h
+++ b/Engine/game_object.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "application.h"
 #include "engine_util.h"
 #include "Components/component.h"
 #include "Components/transform.h"
@@ -10,12 +11,12 @@ class Scene;
 
 class GameObject final : public Object
 {
-    friend class RectTransform;
-
 public:
     explicit GameObject();
 
     void OnConstructed() override;
+
+    void OnDeserialized() override;
 
     void OnDestroy() override;
 
@@ -46,12 +47,14 @@ public:
         instance->m_game_object_ = shared_from_base<GameObject>();
         m_components_.push_back(instance);
 
-        instance->OnAwake();
-        instance->m_has_called_awake_ = true;
+        if (Application::IsPlayMode())
+        {
+            instance->InvokeOnAwake();
+        }
 
         if (IsActiveInHierarchy())
         {
-            instance->OnEnabled();
+            instance->InvokeOnEnabled();
         }
 
         Logger::Log<GameObject>("[%s]: Added component '%s'", Path().c_str(), instance->Name().c_str());
@@ -164,18 +167,14 @@ private:
     friend class Physics;
 
     bool m_is_active_self_ = true;
-    mutable bool m_is_active_in_hierarchy_ = true;
+    mutable bool m_is_active_in_hierarchy_ = false;
     std::weak_ptr<engine::Scene> m_scene_ = {};
     std::vector<std::shared_ptr<Component>> m_components_ = {};
 
-    static void EnsureComponentPrepared(const std::shared_ptr<Component> &component);
-    static void InvokeComponentOnEnabled(const std::shared_ptr<Component> &component);
-    static void InvokeComponentOnDisabled(const std::shared_ptr<Component> &component);
-
-    void InvokeUpdate();
-    void InvokeFixedUpdate() const;
+    void InvokeOnUpdate();
+    void InvokeOnFixedUpdate() const;
     void InvokeOnValidate() const;
-    void UpdateActiveInHierarchy() const;
+    void UpdateActiveInHierarchy(bool invoke_component_events) const;
 
     void InvokeOnCollisionEnter(const Collision &collision) const;
     void InvokeOnCollisionStay(const Collision &collision) const;

--- a/Engine/scene.cpp
+++ b/Engine/scene.cpp
@@ -2,6 +2,7 @@
 
 #include "scene.h"
 
+#include "application.h"
 #include "game_object.h"
 #include "update_manager.h"
 
@@ -17,7 +18,10 @@ void Scene::OnConstructed()
     for (const auto &game_object : m_all_game_objects_)
     {
         game_object->m_scene_ = self;
-        game_object->InvokeOnValidate();
+        if (!Application::IsPlayMode())
+        {
+            game_object->InvokeOnValidate();
+        }
     }
 }
 
@@ -28,7 +32,10 @@ void Scene::OnDeserialized()
     for (const auto &game_object : m_all_game_objects_)
     {
         game_object->m_scene_ = self;
-        game_object->InvokeOnValidate();
+        if (!Application::IsPlayMode())
+        {
+            game_object->InvokeOnValidate();
+        }
     }
 }
 
@@ -37,7 +44,7 @@ void Scene::OnUpdate()
     const auto root_objects = m_root_game_objects_;
     for (const auto &game_object : root_objects)
     {
-        game_object->InvokeUpdate();
+        game_object->InvokeOnUpdate();
     }
 }
 
@@ -45,7 +52,7 @@ void Scene::OnFixedUpdate()
 {
     for (const auto &game_object : m_root_game_objects_)
     {
-        game_object->InvokeFixedUpdate();
+        game_object->InvokeOnFixedUpdate();
     }
 }
 
@@ -65,7 +72,9 @@ void Scene::OnGarbageCollect()
 {
     if (m_has_destroying_game_object_)
     {
-        const auto is_destroying = [](const auto &go) { return go->IsDestroying(); };
+        const auto is_destroying = [](const auto &go) {
+            return go->IsDestroying();
+        };
         std::erase_if(m_root_game_objects_, is_destroying);
         std::erase_if(m_all_game_objects_, is_destroying);
         m_has_destroying_game_object_ = false;
@@ -97,8 +106,18 @@ void Scene::MoveGameObject(const std::shared_ptr<GameObject> &go)
     // handle ownership change 
     if (prev_scene != this_scene && prev_scene != nullptr)
     {
-        erase_if(prev_scene->m_all_game_objects_, [&go](const auto &a) { return a == go; });
-        erase_if(prev_scene->m_root_game_objects_, [&go](const auto &a) { return a == go; });
+        erase_if(
+            prev_scene->m_all_game_objects_,
+            [&go](const auto &a) {
+                return a == go;
+            }
+        );
+        erase_if(
+            prev_scene->m_root_game_objects_,
+            [&go](const auto &a) {
+                return a == go;
+            }
+        );
     }
 
     // refresh current status
@@ -122,7 +141,12 @@ void Scene::MoveGameObject(const std::shared_ptr<GameObject> &go)
     }
     else
     {
-        erase_if(m_root_game_objects_, [&go](const auto &a) { return a == go; });
+        erase_if(
+            m_root_game_objects_,
+            [&go](const auto &a) {
+                return a == go;
+            }
+        );
     }
 
     // update child objects


### PR DESCRIPTION
* Editor から Play に遷移するときにシーンを Deserialize するようになったよ
* Editor 上で OnAwake, OnStart が呼ばれなくなったよ
  * OnEnabled, OnDisabled に関しては引き続き Editor 上でも呼ばれるよ
  * 変わりに OnValidate が呼ばれるから、それで処理してね
* シーン開始時に OnDeserialized -> OnAwake -> OnEnabled -> OnStart -> OnUpdate / OnFixedUpdate の順で呼ばれることを保証するようになったよ
  * なお OnAwake の先に関しては、GameObject が IsActiveInHierarchy() でない場合、SetActive(true) まで待つよ